### PR TITLE
Disable automatic Supabase token refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -173,7 +173,12 @@
   <script>
     const SUPA_URL = 'https://dieltjdqgeppyixximwe.supabase.co';
     const SUPA_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRpZWx0amRxZ2VwcHlpeHhpbXdlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDEwMzY2MzMsImV4cCI6MjA1NjYxMjYzM30.NXZfUyvyrPzAeT75vWWWjY5h1LOe_vwaFiHBS1TMwtw';
-    const sb = supabase.createClient(SUPA_URL, SUPA_KEY);
+    const sb = supabase.createClient(SUPA_URL, SUPA_KEY, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false
+      }
+    });
 
     let currentUserId = null,
         map, markers = {}, foodLocations = [], selectedCoordinates = null, selectedImage = null;

--- a/login.html
+++ b/login.html
@@ -100,7 +100,12 @@
   <script>
     const supabaseUrl = 'https://dieltjdqgeppyixximwe.supabase.co';
     const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRpZWx0amRxZ2VwcHlpeHhpbXdlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDEwMzY2MzMsImV4cCI6MjA1NjYxMjYzM30.NXZfUyvyrPzAeT75vWWWjY5h1LOe_vwaFiHBS1TMwtw';
-    const sb = supabase.createClient(supabaseUrl, supabaseKey);
+    const sb = supabase.createClient(supabaseUrl, supabaseKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false
+      }
+    });
     
     const loginBtn = document.getElementById('login-btn');
     const errorMsg = document.getElementById('error-message');

--- a/map.html
+++ b/map.html
@@ -32,7 +32,12 @@
       // Initialize your client (be sure to paste your full key)
       const SUPA_URL = 'https://dieltjdqgeppyixximwe.supabase.co';
       const SUPA_KEY = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRpZWx0amRxZ2VwcHlpeHhpbXdlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDEwMzY2MzMsImV4cCI6MjA1NjYxMjYzM30.NXZfUyvyrPzAeT75vWWWjY5h1LOe_vwaFiHBS1TMwtw';
-      const sb = createClient(SUPA_URL, SUPA_KEY);
+      const sb = createClient(SUPA_URL, SUPA_KEY, {
+        auth: {
+          persistSession: false,
+          autoRefreshToken: false
+        }
+      });
 
       // Set up the map
       const map = L.map('map', { center:[31.7683,35.2137], zoom:8 });

--- a/register.html
+++ b/register.html
@@ -111,7 +111,12 @@
   <script>
     const supabaseUrl = 'https://dieltjdqgeppyixximwe.supabase.co';
     const supabaseKey = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRpZWx0amRxZ2VwcHlpeHhpbXdlIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDEwMzY2MzMsImV4cCI6MjA1NjYxMjYzM30.NXZfUyvyrPzAeT75vWWWjY5h1LOe_vwaFiHBS1TMwtw';
-    const sb = supabase.createClient(supabaseUrl, supabaseKey);
+    const sb = supabase.createClient(supabaseUrl, supabaseKey, {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false
+      }
+    });
     
     const registerBtn = document.getElementById('register-btn');
     const errorMsg = document.getElementById('error-message');


### PR DESCRIPTION
## Summary
- prevent Supabase JS from auto refreshing tokens to avoid repeated network errors

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689527cbb1ac832cadb0777f83e16524